### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A lightweight UIScrollView block-driven subclass for easily create multiple page
 
 ![alt text](https://raw.github.com/AlvaroFranco/AFScrollView/master/preview.gif "Example")
 
-##Cocoapods
+##CocoaPods
 
 AFScrollView is on [CocoaPods](http://cocoapods.org), so you can get the pod by adding this line to your Podfile
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
